### PR TITLE
Improve HUD spacing and selection behavior

### DIFF
--- a/components/AppleExactHeatmap.tsx
+++ b/components/AppleExactHeatmap.tsx
@@ -492,9 +492,13 @@ export function AppleExactHeatmap() {
   }, [])
 
   return (
-    <div className="w-full h-screen bg-black relative flex items-center justify-center">
+    <div className="w-full h-screen bg-black relative flex items-center justify-center select-none">
       <Leva hidden={levaHidden} />
-      <div className="absolute top-4 left-4 text-white text-sm font-mono z-10">
+      <div
+        className="absolute left-4 text-white text-sm font-mono z-10 select-text"
+        style={{ top: "calc(env(safe-area-inset-top) + 1rem)" }}
+      >
+        <div>Apple Event experience recreation</div>
         <div>press L to toggle controls</div>
         <div>
           ported by{" "}


### PR DESCRIPTION
## Summary
- prevent text overlay from overlapping the iPhone notch by using `env(safe-area-inset-top)`
- add `select-none` to scene and `select-text` to overlay so only text is selectable
- show "Apple Event experience recreation" above the existing toggle controls hint

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68ae772fda708320bc06d43be2683e17